### PR TITLE
file upload button in separate list

### DIFF
--- a/attachment-list-upload.html
+++ b/attachment-list-upload.html
@@ -28,7 +28,9 @@
             </li>
         {% endfor %}
     {% endunless %}
-
+</ul>
+<ul class="attachment-list attachments"
+    id="attachment-upload">
     {% if include.modal %}
         <li 
             class="upload-area">


### PR DESCRIPTION
Use a separate ul/li structure for the file upload button.

After a successful file upload the form in which the file upload happens is submitted. In our implementation in Plone we have a pat-inject on that form which does a request to the backend which returns the updated attachment list which is then replacing the old one.
For this to happen I need the file upload button in another `<ul>`, otherwise the file upload button would also be replaced by the markup returned to pat-inject.

There is of course no need that the upload button stays in a `<ul>`, but the design is almost right when doing so.

With this change the file upload form looks like the following. Please note the white line between the attachment list and the upload button.

![Screenshot from 2022-10-08 01-07-24](https://user-images.githubusercontent.com/170891/194674705-2aeaf0ec-d879-4cc5-a38f-0dbae9acd456.png)


Related:
https://github.com/Patternslib/patterns-includes/pull/1
https://github.com/syslabcom/oira.prototype/pull/391

/cc @cornae @pilz