### PR TITLE
help-pages: Fix missing whitespace between href and class attributes.

### DIFF
--- a/open-modal.html
+++ b/open-modal.html
@@ -2,10 +2,10 @@
     <a 
         tabindex="0"
         href="{{ include.href }}"
-        {%- if include.title -%}
+        {% if include.title %}
             {%- assign this_title = include.title -%}
             title="{%- include patterns/i18n sentinel=false id=this_title -%}"
-        {%- endif -%}
+        {% endif %}
         class="
             pat-inject 
             {{ include.class }}"


### PR DESCRIPTION
The Liquid template syntax for ``{%- ... -%}`` removes all whitespace around the curly braces and so it will remove concatenate the href and class attributes and produce invalid HTML.

Before:
```html
    <a 
        tabindex="0"
        href="/feedback/panel-unlock-validated-risk-assessment"class="
            pat-inject 
            icon-lock-open close-panel"
        data-pat-inject="
            source: #pat-modal-panel-space; 
            target: #pat-modal-panel-space; 
            url: /feedback/panel-unlock-validated-risk-assessment;">Unlock and invalidate</a>
```

after:
```html
    <a 
        tabindex="0"
        href="/feedback/panel-unlock-validated-risk-assessment"
        
        class="
            pat-inject 
            icon-lock-open close-panel"
        data-pat-inject="
            source: #pat-modal-panel-space; 
            target: #pat-modal-panel-space; 
            url: /feedback/panel-unlock-validated-risk-assessment;">Unlock and invalidate</a>
```